### PR TITLE
leagueApiClient and LeagueDTO and controller modify

### DIFF
--- a/src/main/java/org/ajou/realcoding/lol/homeworklol/api/SummonerLeaguePosiApiClient.java
+++ b/src/main/java/org/ajou/realcoding/lol/homeworklol/api/SummonerLeaguePosiApiClient.java
@@ -3,25 +3,30 @@ package org.ajou.realcoding.lol.homeworklol.api;
 
 import org.ajou.realcoding.lol.homeworklol.domain.LeagueDTO;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
 
 @Service
 public class SummonerLeaguePosiApiClient { //api를 통해  얻은 id로 소환사의 게임 성적을 얻는 api client
     private final String appid = "RGAPI-6c0cb8cd-0bb0-49a8-a50c-9d65c424edd7";
-    private final String summonerPositionUrl = "https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/{id}?api_key={appid}";
+    private final String summonerPositionUrl = "https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/{summonerid}?api_key={appid}";
 
 
     @Autowired
     RestTemplate restTemplate;
     //league 성적 정보는 riot 홈페이지에서 set 즉, 여러개 나와서 배열로 만들어서 배열에 하나씩 가져온 정보를 읽어오도록
-    public LeagueDTO requestLeagueDTO(String summonerId)
+    public List<LeagueDTO> requestLeagueDTO(String summonerId)
     {
-        LeagueDTO leaguePosition = restTemplate.exchange(summonerPositionUrl, HttpMethod.GET,null, LeagueDTO.class,summonerId,appid).getBody();
+        ResponseEntity<List<LeagueDTO>> leagueDTOS = restTemplate.exchange(summonerPositionUrl, HttpMethod.GET,null, new ParameterizedTypeReference<List<LeagueDTO>>() {},summonerId,appid);
+        List<LeagueDTO> leagueEntryDTO = leagueDTOS.getBody();
         //leagueDTOS.add(leagueDTO);*
         //leagueDTOS.add(restTemplate.exchange(summonerPositionUrl, HttpMethod.GET,null,LeagueDTO.class,summonerId,appid).getBody());*/
-        return leaguePosition;
+        return leagueEntryDTO;
     }
 
 

--- a/src/main/java/org/ajou/realcoding/lol/homeworklol/controller/SummonerNameController.java
+++ b/src/main/java/org/ajou/realcoding/lol/homeworklol/controller/SummonerNameController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.ajou.realcoding.lol.homeworklol.service.LolencryptedSummonerIdService;
 
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 public class SummonerNameController {
@@ -25,12 +26,16 @@ public class SummonerNameController {
     private SummonerLeaguePosiApiClient summonerLeaguePosiApiClient;
 
     @GetMapping("/lol/summoner/v4/summoners/by-name/{summonerName}")
-    public LeagueDTO getSummonerLeaguePosition(@PathVariable String summonerName) throws IOException {
+    public SummonerDTO getSummonerId(@PathVariable String summonerName) throws IOException {
         SummonerDTO summonerDTO = summonerIdApiClient.requestSummonerDTO(summonerName);
-        String summonerId = summonerDTO.getId();
-        LeagueDTO leaguePosition = summonerLeaguePosiApiClient.requestLeagueDTO(summonerId);
-        return leaguePosition;
+        return summonerDTO;
         //소환사 이름을 통해서 id를 얻는 api client에 선언된 함수를 호출해서 얻어오는 함수
+    }
+    @GetMapping("/lol/league/v4/entries/by-summoner/{summonerId}")
+    public List<LeagueDTO> getSummonerLeagueInfo(@PathVariable String summonerId)
+    {
+        List<LeagueDTO> leagueInfo = summonerLeaguePosiApiClient.requestLeagueDTO(summonerId);
+        return leagueInfo;
     }
 
 

--- a/src/main/java/org/ajou/realcoding/lol/homeworklol/domain/LeagueDTO.java
+++ b/src/main/java/org/ajou/realcoding/lol/homeworklol/domain/LeagueDTO.java
@@ -8,26 +8,22 @@ import java.util.Set;
 
 @Data
 public class LeagueDTO {
-    private Set<LeagueEntryDTO> leagues;
+    private String queueType;
+    private String summonerName;
+    private boolean hotStreak;
+    private MiniSeriesDTO miniSeries;
+    private int wins;
+    private boolean veteran;
+    private int losses;
+    private String rank;
+    private String leagueId;
+    private boolean inactive;
+    private boolean freshBlood;
+    private String tier;
+    private String summonerId;
+    private int leaguePoints;
 
-    @Data
-    public static class LeagueEntryDTO {
-        private String queueType;
-        private String summonerName;
-        private boolean hotStreak;
-        private Set<MiniSeriesDTO> miniSeries;
-        private int wins;
-        private boolean veteran;
-        private int losses;
-        private String rank;
-        private String leagueId;
-        private boolean inactive;
-        private boolean freshBlood;
-        private String tier;
-        private String summonerId;
-        private int leaguePoints;
 
-    }
     @Data
     public static class MiniSeriesDTO {
         private String progress;


### PR DESCRIPTION
1) league 성적 정보 얻어오는 api 수정했습니다. response 값 배열로 받아야해 responseentity 랑 typereference 이용했는데 https://stackoverflow.com/questions/51896979/correct-usage-of-parameterizedtypereference 여기 참고하시면 이해가 빠를 것 같습니당
2) leagueDTO를 여기 안에서 원래 배열로 선언한거를 그냥 api 홈페이지에 나와있는대로 수정하였습니다. 
3) controller도 추가했습니다
